### PR TITLE
Show wrist pocket icons on map change

### DIFF
--- a/game/hlvr/scripts/vscripts/wristpockets.lua
+++ b/game/hlvr/scripts/vscripts/wristpockets.lua
@@ -113,8 +113,13 @@ function WristPockets_CheckPocketItemsOnLoading(playerEnt, saveLoading)
 		if not saveLoading then -- erase teleported items on level change
 			ErasePocketSlot(playerEnt, 1)
 			ErasePocketSlot(playerEnt, 2)
+			-- This delay of calling update hud function will show wrist pocket icons on map change
+			playerEnt:SetThink(function()
+				WristPockets_UpdateHUD()
+			end, "WristPockets_MapChange", 1)
+		else
+			WristPockets_UpdateHUD()
 		end
-		WristPockets_UpdateHUD()
 	end -- on first appear, icons can be too bold because of antialiasing bug
 	PrecacheModels()
 end


### PR DESCRIPTION
@VladManyanov @bfeber 

This change enables wrist pocket icons to load after a map change.
I use the existing player object and call a SetThink function with a small delay to call UpdateHUD.