### PR TITLE
Healthpen inject if player has no free pocket slot

### DIFF
--- a/game/hlvr/scripts/vscripts/useextra.lua
+++ b/game/hlvr/scripts/vscripts/useextra.lua
@@ -1351,7 +1351,7 @@ elseif class == "item_hlvr_grenade_frag" then
 		end
     end
 elseif class == "item_healthvial" then
-    if player:GetHealth() < player:GetMaxHealth() then
+    if player:GetHealth() < (player:GetMaxHealth() - 15) or (WristPockets_PlayerHasFreePocketSlot(player) == false and player:GetHealth() < player:GetMaxHealth()) then
         player:SetContextNum("used_health_pen", 1, 10)
         player:SetHealth(min(player:GetHealth() + cvar_getf("hlvr_health_vial_amount"), player:GetMaxHealth()))
         FireGameEvent("item_pickup", item_pickup_params)

--- a/game/hlvr/scripts/vscripts/wristpockets.lua
+++ b/game/hlvr/scripts/vscripts/wristpockets.lua
@@ -90,6 +90,14 @@ local function GetFreePocketSlot(playerEnt)
 	return 0 -- no free slots
 end
 
+function WristPockets_PlayerHasFreePocketSlot(playerEnt)
+	if GetFreePocketSlot(playerEnt) ~= 0 then
+		return true
+	else
+		return false
+	end
+end
+
 local function ErasePocketSlot(playerEnt, itemSlot)
 	if not Storage:LoadBoolean("pocketslots_slot" .. itemSlot .. "_keepacrossmaps") then
 		playerEnt:Attribute_SetIntValue("pocketslots_slot" .. itemSlot .. "", 0)


### PR DESCRIPTION
Use health vial if player has < 85 health or pockets are full and health < 100.