### PR TITLE
hide hud hearts on a1_intro_world maps

### DIFF
--- a/game/hlvr/scripts/vscripts/hudhearts.lua
+++ b/game/hlvr/scripts/vscripts/hudhearts.lua
@@ -16,11 +16,13 @@ function HUDHearts_StartupPreparations()
 	end
 
 	-- Trigger initial hearts update
-	local player = Entities:GetLocalPlayer()
-	player:SetThink(function()
-		HUDHearts_Background()
-		HUDHearts_UpdateHealth()
-	end, "HUDHearts_MapChange", 1)
+	if GetMapName() ~= "a1_intro_world" and GetMapName() ~= "a1_intro_world_2" then
+		local player = Entities:GetLocalPlayer()
+		player:SetThink(function()
+			HUDHearts_Background()
+			HUDHearts_UpdateHealth()
+		end, "HUDHearts_MapChange", 1)
+	end
 
 	print("[HUDHearts] Start up done")
 end
@@ -85,9 +87,38 @@ function HUDHearts_UpdateHealth()
 	print(string.format("[HUDHearts] Set heart icons to %s health", health))
 end
 
+function HUDHearts_Hide()
+	local textEntityBackground = Entities:FindByName(nil, "text_hearts_background")
+	local textEntity = Entities:FindByName(nil, "text_hearts")
+	local textEntityRed = Entities:FindByName(nil, "text_hearts_red")
+
+	DoEntFireByInstanceHandle(textEntityBackground, "SetText", "", 0, nil, nil)
+	DoEntFireByInstanceHandle(textEntityBackground, "Display", "", 0, nil, nil)
+	DoEntFireByInstanceHandle(textEntity, "SetText", "", 0, nil, nil)
+	DoEntFireByInstanceHandle(textEntity, "Display", "", 0, nil, nil)
+	DoEntFireByInstanceHandle(textEntityRed, "SetText", "", 0, nil, nil)
+	DoEntFireByInstanceHandle(textEntityRed, "Display", "", 0, nil, nil)
+
+	print("[HUDHearts] Hide hud hearts")
+end
+
+function HUDHearts_Show()
+	HUDHearts_Background()
+	HUDHearts_UpdateHealth()
+	print("[HUDHearts] Show hud hearts")
+end
+
 Convars:RegisterCommand("hudhearts_updatehealth" , function()
 	HUDHearts_UpdateHealth()
 end, "Update hud heart icons", 0)
+
+Convars:RegisterCommand("hudhearts_hide" , function()
+	HUDHearts_Hide()
+end, "Hide hud heart icons", 0)
+
+Convars:RegisterCommand("hudhearts_show" , function()
+	HUDHearts_Show()
+end, "Show hud heart icons", 0)
 
 Convars:RegisterCommand("hudhearts_recreate" , function()
 	SendToConsole("ent_remove text_hearts_background")

--- a/game/hlvr/scripts/vscripts/novr.lua
+++ b/game/hlvr/scripts/vscripts/novr.lua
@@ -27,7 +27,9 @@ if GlobalSys:CommandLineCheck("-novr") then
         end
 
         -- Update hud hearts
-        HUDHearts_UpdateHealth()
+        if GetMapName() ~= "a1_intro_world" and GetMapName() ~= "a1_intro_world_2" then
+            HUDHearts_UpdateHealth()
+        end
 
     end, nil)
 
@@ -915,6 +917,13 @@ if GlobalSys:CommandLineCheck("-novr") then
                 else
                     SendToConsole("hidehud 64")
                     SendToConsole("r_drawviewmodel 1")
+                end
+
+                -- Show hud hearts if player picked up the gravity gloves
+                if ent:Attribute_GetIntValue("gravity_gloves", 0) ~= 0 then
+                    ent:SetThink(function()
+                        HUDHearts_Show()
+                    end, "", 1.5)
                 end
 
                 SendToConsole("combine_grenade_timer 7")

--- a/game/hlvr/scripts/vscripts/useextra.lua
+++ b/game/hlvr/scripts/vscripts/useextra.lua
@@ -620,6 +620,7 @@ end
 if name == "glove_dispenser_brush" then
     SendToConsole("ent_fire relay_give_gravity_gloves trigger")
     SendToConsole("hidehud 1")
+    SendToConsole("hudhearts_show")
     Entities:GetLocalPlayer():Attribute_SetIntValue("gravity_gloves", 1)
 end
 
@@ -684,6 +685,8 @@ if name == "l_candler" or name == "r_candler" then
     else
         SendToConsole("hidehud 4")
     end
+    -- Just to make sure the heart icons are gone, hidehud 4 seems fine
+    SendToConsole("hudhearts_hide")
 end
 
 if name == "combine_gun_mechanical" then


### PR DESCRIPTION
Fix for hud hearts on intro maps. Also validated that a5_ending is fine